### PR TITLE
Use GE proton-experimental patch set

### DIFF
--- a/.github/workflows/tarball.yaml
+++ b/.github/workflows/tarball.yaml
@@ -8,7 +8,7 @@ on:
   workflow_dispatch:
 env:
   PROTON_GE_RELEASE: "GE-Proton7-8"
-  RELEASE: "1"
+  RELEASE: "2"
 jobs:
   build:
     runs-on: "ubuntu-latest"
@@ -24,7 +24,7 @@ jobs:
           submodules: "recursive"
           fetch-depth: 0
       - name: "Apply patches"
-        run: "./patches/protonprep.sh"
+        run: "./patches/protonprep-valve.sh"
       - name: "Store vdk3d-proton's build hash"
         run: "git describe --always --exclude=* --abbrev=15 --dirty=0 > BUILD"
         working-directory: "vkd3d-proton"


### PR DESCRIPTION
Patches are now applied with `patches/protonprep-valve.sh` as GE uses the proton-experimental branch.

https://github.com/GloriousEggroll/proton-ge-custom/commit/13a39399e5814828d274bfb54d5af303e9aaed77
https://github.com/GloriousEggroll/proton-ge-custom/commit/c31dfdda37ba8e7033865bfcc9126e2936b1f684