### PR TITLE
Auto update at 10:00 UTC

### DIFF
--- a/.github/workflows/auto-update.yaml
+++ b/.github/workflows/auto-update.yaml
@@ -2,7 +2,7 @@ name: "Auto Update"
 
 on:
   schedule:
-    - cron: "0 0 * * *"
+    - cron: "0 10 * * *"
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Looking through the releases the they seem to be published between 20:00 and 9:00 UTC.
Checking for updates at 10:00 should get allow builds to get on to flathub faster.

Is there any reason not to check more frequently?
`0 */3 * * *` would be 8 times a day?